### PR TITLE
Correction of location of HTML files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,4 +13,4 @@ include setup.py
 recursive-include src/itaxotools/**/resources *
 
 # Include data files
-include src/itaxotools/fasttreepy/gui/docs/*.html
+include src/itaxotools/concatenator/gui/docs/*.html


### PR DESCRIPTION
MANIFEST.in seem to have incorrect location for doc/*.html files. I corrected it to the value that seems to work