### PR TITLE
Replace ssh for https in git clone

### DIFF
--- a/packages.html
+++ b/packages.html
@@ -7,37 +7,37 @@
       itaxotools-common-0.2.1</a><br/>
     <a href="git+https://git@github.com/iTaxoTools/itt-common.git@v0.2.2#egg=itaxotools-common-0.2.2">
       itaxotools-common-0.2.2</a><br/>
-    <a href="git+ssh://git@github.com/iTaxoTools/itt-common.git@v0.2.2#egg=itaxotools-common-0.2.2">
+    <a href="git+https://git@github.com/iTaxoTools/itt-common.git@v0.2.2#egg=itaxotools-common-0.2.2">
       itaxotools-common-0.2.2</a><br/>
   </div>
   <div name="concatenator">
     <a href="git+https://git@github.com/iTaxoTools/concatenator.git@v0.2.1#egg=concatenator-0.2.1">
       concatenator-0.2.1</a><br/>
-    <a href="git+ssh://git@github.com/iTaxoTools/concatenator.git@v0.2.1#egg=concatenator-0.2.1">
+    <a href="git+https://git@github.com/iTaxoTools/concatenator.git@v0.2.1#egg=concatenator-0.2.1">
       concatenator-0.2.1</a><br/>
   </div>
   <div name="DNAconvert">
     <a href="git+https://git@github.com/iTaxoTools/DNAconvert.git@v0.2.0#egg=DNAconvert-0.2.0">
       DNAconvert-0.2.0</a><br/>
-    <a href="git+ssh://git@github.com/iTaxoTools/DNAconvert.git@v0.2.0#egg=DNAconvert-0.2.0">
+    <a href="git+https://git@github.com/iTaxoTools/DNAconvert.git@v0.2.0#egg=DNAconvert-0.2.0">
       DNAconvert-0.2.0</a><br/>
   </div>
   <div name="MAFFTpy">
     <a href="git+https://git@github.com/iTaxoTools/MAFFTpy.git@v0.1.2#egg=mafftpy-0.1.2">
       mafftpy-0.1.2</a><br/>
-    <a href="git+ssh://git@github.com/iTaxoTools/MAFFTpy.git@v0.1.2#egg=mafftpy-0.1.2">
+    <a href="git+https://git@github.com/iTaxoTools/MAFFTpy.git@v0.1.2#egg=mafftpy-0.1.2">
       mafftpy-0.1.2</a><br/>
   </div>
   <div name="FastTreePy">
     <a href="git+https://git@github.com/iTaxoTools/FastTreePy.git@main#egg=fasttreepy-0.2.0">
       fasttreepy-0.2.0</a><br/>
-    <a href="git+ssh://git@github.com/iTaxoTools/FastTreePy.git@main#egg=fasttreepy-0.2.0">
+    <a href="git+https://git@github.com/iTaxoTools/FastTreePy.git@main#egg=fasttreepy-0.2.0">
       fasttreepy-0.2.0</a><br/>
   </div>
   <div name="sequence_bouncer">
     <a href="git+https://git@github.com/iTaxoTools/SequenceBouncer.git@v1.23.1#egg=sequence_bouncer-1.23.1">
       sequence_bouncer-1.23.1</a><br/>
-    <a href="git+ssh://git@github.com/iTaxoTools/SequenceBouncer.git@v1.23.1#egg=sequence_bouncer-1.23.1">
+    <a href="git+https://git@github.com/iTaxoTools/SequenceBouncer.git@v1.23.1#egg=sequence_bouncer-1.23.1">
       sequence_bouncer-1.23.1</a><br/>
   </div>
 </html>


### PR DESCRIPTION
By replacing ssh in some url's it avoids errors in git clone for users that don't have ssh keys properly set up on github